### PR TITLE
Heartbeat plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test:
-	node tests/basictests.js
+	node tests/heartbeat-sender-tests.js
 
 pushall:
 	git push origin master && npm publish

--- a/README.md
+++ b/README.md
@@ -8,7 +8,15 @@ It is not a standard Node or browser module (as of now), but rather, a way to pa
 Installation
 ------------
 
+When using as a dependency in another project:
+
     npm install dce-paella-extensions
+
+When working on this module:
+
+    git clone git@github.com:harvard-dce/dce-paella-extensions
+    git checkout <branch name>
+    npm install
 
 Usage
 -----
@@ -17,6 +25,14 @@ You need to copy your stuff out of this module to where you need it yourself. So
 
 Development
 -----------
+
+**Local development**
+
+- Edit the files you want.
+- Run tests as documented in the next section.
+- When you are ready to publish to NPM, make sure you update the version in package.json.
+
+**Testing a development version of this module in paella-matterhorn**
 
 To avoid having to run `npm publish` and `npm install` just to see if a change worked in the context of paella-matterhorn, you can:
 

--- a/README.md
+++ b/README.md
@@ -24,14 +24,33 @@ To avoid having to run `npm publish` and `npm install` just to see if a change w
 - Run `npm link dce-paella-extensions` in the paella-matterhorn directory. Now there will be a symlink-like link to the project.
 - Then, run `grunt build.debug` in paella-matterhorn.
 
+Tests
+-----
+
+There is only one set of tests so far. To run it, assuming you have already run `npm install`:
+
+    make test
+
+You should see output that looks like this:
+
+    TAP version 13
+    # Heartbeat test
+    ok 1 Passes a function to the timer.
+    ok 2 Sets the timer to run at the interval specified in the config.
+    ok 3 The heartbeat event is registered.
+    ok 4 Sets the timer to repeat.
+
+    1..4
+    # tests 4
+    # pass  4
+
+    # ok
+
+Any change you make a PR for should end in a test run with 'ok'; no failures.
+
 DCE modifications not installed by this package
 -----------------------------------------------
 
 - Gruntfile.js
 - config/config.json
 - plugins/es.upv.paella.*
-
-Tests
------
-
-Run tests with `make test`.

--- a/config/config.json
+++ b/config/config.json
@@ -75,7 +75,7 @@
         "showMasterVolume": true,
         "showSlaveVolume": false
       },
-      "es.upv.paella.userTrackingCollectorPlugIn": {
+      "edu.harvard.dce.paella.heartbeatSender": {
         "enabled": true,
         "heartBeatTime": 5000
       },

--- a/config/config.json
+++ b/config/config.json
@@ -77,7 +77,7 @@
       },
       "edu.harvard.dce.paella.heartbeatSender": {
         "enabled": true,
-        "heartBeatTime": 5000
+        "heartBeatTime": 30000
       },
       "es.upv.paella.matterhorn.userTrackingSaverPlugIn": {
         "enabled": true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dce-paella-extensions",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "Harvard DCE Extensions for the Paella video player",
   "main": "index.js",
   "scripts": {
@@ -22,7 +22,9 @@
   },
   "homepage": "https://github.com/jimkang/dce-paella-extensions",
   "devDependencies": {
-    "tape": "^3.0.3"
+    "call-next-tick": "^1.1.2",
+    "lodash": "^3.10.1",
+    "tape": "^4.2.0"
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dce-paella-extensions",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "Harvard DCE Extensions for the Paella video player",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dce-paella-extensions",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "Harvard DCE Extensions for the Paella video player",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:jimkang/dce-paella-extensions.git"
+    "url": "git@github.com:harvard-dce/dce-paella-extensions.git"
   },
   "keywords": [
     "video",
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/jimkang/dce-paella-extensions/issues"
   },
-  "homepage": "https://github.com/jimkang/dce-paella-extensions",
+  "homepage": "https://github.com/harvard-dce/dce-paella-extensions",
   "devDependencies": {
     "call-next-tick": "^1.1.2",
     "lodash": "^3.10.1",

--- a/tests/heartbeat-sender-tests.js
+++ b/tests/heartbeat-sender-tests.js
@@ -25,8 +25,8 @@ var mockPaellaObject = {
   }
 };
 
-test('Heartbeat test', function heartbeatTest(t) {
-  t.plan(12);
+test('Heartbeat tests', function heartbeatTests(t) {
+  t.plan(13);
 
   // Set up mocks and checks.
   setUpMocks();
@@ -77,33 +77,41 @@ function setUpAssertingMocks(t) {
 
   function checkHeartbeatURL(URL) {
     var urlParts = url.parse(URL, true);
+    var query = urlParts.query;
+
     t.equal(urlParts.protocol, 'https:', 'Request is sent via https.');
     t.equal(urlParts.pathname, '/usertracking/', 'Request pathname is correct.');
+
     t.equal(
-      urlParts.query._method, 'PUT', 'Sends "PUT" as the "_method" query param.'
+      query._method, 'PUT', 'Sends "PUT" as the "_method" query param.'
     );
     t.equal(
-      urlParts.query.id,
+      query.id,
       mockPaellaObject.player.videoIdentifier,
       'id query param is set to the value of paella.player.videoIdentifier.'
     );
+    t.equal(query.type, 'HEARTBEAT', 'type query param is correct.');
     t.equal(
-      urlParts.query.type, 'HEARTBEAT', 'type query param is correct.'
-    );
-    t.equal(
-      parseInt(urlParts.query.in, 10),
+      parseInt(query.in, 10),
       mockCurrentTime() + mockTrimStart(),
       '"in" query param is set to currentTime + trimStart.'
     );
     t.equal(
-      parseInt(urlParts.query.out, 10),
+      parseInt(query.out, 10),
       mockCurrentTime() + mockTrimStart(),
       '"out" query param is also set to currentTime + trimStart.'
     );
     t.equal(
-      urlParts.query.resource,
+      query.resource,
       mockPaellaObject.matterhorn.resourceId,
       'resource query param is set to the value of paella.matterhorn.resourceId.'
+    );
+
+    var timestamp = new Date(query._);
+    t.equal(
+      typeof timestamp,
+      'object',
+      'The timestamp ("_") query param is a valid date.'
     );
   }
 }

--- a/tests/heartbeat-sender-tests.js
+++ b/tests/heartbeat-sender-tests.js
@@ -1,0 +1,94 @@
+var test = require('tape');
+var _ = require('lodash');
+var callNextTick = require('call-next-tick');
+
+var mockConfig = {
+  heartBeatTime: 100          
+};
+
+test('Heartbeat test', function heartbeatTest(t) {
+  t.plan(4);
+
+  // Set up mocks and checks.
+  setUpTopLevelGlobalMocks({
+    classMethods: {
+      registerEvent: mockRegisterEvent
+    }
+  });
+  setUpAssertingMocks();
+
+
+  // Loading the plugin code actually executes the plugin.
+  // That is how Paella plugins work.
+  require('../vendor/plugins/edu.harvard.dce.paella.heartbeatSender/heartbeat_sender');
+
+
+  function setUpAssertingMocks() {
+    global.base.Timer = timer;
+  }
+
+  function timer(callback, time, params) {
+    t.equal(
+      typeof callback,
+      'function',
+      'Passes a function to the timer.'
+    );
+    t.equal(
+      time,
+      mockConfig.heartBeatTime,
+      'Sets the timer to run at the interval specified in the config.'
+    );
+
+    callNextTick(callback, global.base.Timer);
+    callNextTick(checkRepeatValue);
+
+    var instance = this;
+
+    function checkRepeatValue() {
+      t.equal(instance.repeat, true, 'Sets the timer to repeat.');
+    }
+  }
+
+  function mockRegisterEvent(eventName) {
+    t.equal(eventName, 'HEARTBEAT', 'The heartbeat event is registered.');
+  }
+});
+
+
+// opts is not a required parameter. But if you do specify it, here's an example
+// of what is expected:
+// {
+//  classMethods: {
+//    nameOfMethodYouWantAttachedToEveryInstance: function myFn() { ... },
+//    otherMethod: function myOtherFn() { ... }
+//  }
+// }
+function setUpTopLevelGlobalMocks(opts) {
+  global.paella = {
+    EventDrivenPlugin: '',
+    plugins: {}
+  };
+
+  global.base = {};
+
+  global.Class = function Class(classPath, classType, classDef) {
+    var classSegments = classPath.split('.');
+    if (classSegments.length === 3) {
+      global.paella.plugins[classSegments[2]] = createClass;
+    }
+
+    function createClass() {
+      var classInst = _.cloneDeep(classDef);
+      classInst.config = _.cloneDeep(mockConfig);      
+      classInst.setup();
+
+      if (opts && opts.classMethods) {
+        for (methodName in opts.classMethods) {
+          classInst[methodName] = opts.classMethods[methodName];
+        }
+      }
+
+      return classInst;
+    }
+  };
+}

--- a/tests/heartbeat-sender-tests.js
+++ b/tests/heartbeat-sender-tests.js
@@ -27,7 +27,7 @@ var mockPaellaObject = {
 };
 
 test('Heartbeat tests', function heartbeatTests(t) {
-  t.plan(14);
+  t.plan(15);
 
   // Set up mocks and checks.
   setUpMocks();
@@ -68,12 +68,17 @@ function setUpAssertingMocks(t) {
 
   function mockXHR() {
     this.open = mockOpen;
+    this.send = mockSend;
   }
 
   function mockOpen(method, URL) {
     t.equal(method, 'GET', 'Opens a request with the GET method.');
     // t.equal(URL, )
     checkHeartbeatURL(URL);
+  }
+
+  function mockSend() {
+    t.pass('The xhr is actually sent.');
   }
 
   function checkHeartbeatURL(URL) {

--- a/tests/heartbeat-sender-tests.js
+++ b/tests/heartbeat-sender-tests.js
@@ -14,7 +14,11 @@ var mockPaellaObject = {
   EventDrivenPlugin: '',
   plugins: {},
   player: {
-    videoIdentifier: 'the-video-identifier'
+    videoIdentifier: 'the-video-identifier',
+    videoContainer: {
+      currentTime: mockCurrentTime,
+      trimStart: mockTrimStart
+    }
   },
   matterhorn: {
     resourceId: '/2015/03/33383/L10'
@@ -22,7 +26,7 @@ var mockPaellaObject = {
 };
 
 test('Heartbeat test', function heartbeatTest(t) {
-  t.plan(9);
+  t.plan(12);
 
   // Set up mocks and checks.
   setUpMocks();
@@ -83,18 +87,25 @@ function setUpAssertingMocks(t) {
       mockPaellaObject.player.videoIdentifier,
       'id query param is set to the value of paella.player.videoIdentifier.'
     );
-    // t.equal(urlParts.query.in, 0, 'in query param is set to 0.');
-    // t.equal(urlParts.query.out, 0, 'in query param is set to 0.');
-
+    t.equal(
+      urlParts.query.type, 'HEARTBEAT', 'type query param is correct.'
+    );
+    t.equal(
+      parseInt(urlParts.query.in, 10),
+      mockCurrentTime() + mockTrimStart(),
+      '"in" query param is set to currentTime + trimStart.'
+    );
+    t.equal(
+      parseInt(urlParts.query.out, 10),
+      mockCurrentTime() + mockTrimStart(),
+      '"out" query param is also set to currentTime + trimStart.'
+    );
     t.equal(
       urlParts.query.resource,
       mockPaellaObject.matterhorn.resourceId,
       'resource query param is set to the value of paella.matterhorn.resourceId.'
     );
-    debugger;
-
   }
-
 }
 
 // opts is not a required parameter. But if you do specify it, here's an example
@@ -135,3 +146,12 @@ function setUpMocks(opts) {
     }
   };
 }
+
+function mockCurrentTime() {
+  return 300;
+}
+
+function mockTrimStart() {
+  return 200;
+}
+

--- a/tests/heartbeat-sender-tests.js
+++ b/tests/heartbeat-sender-tests.js
@@ -17,7 +17,8 @@ var mockPaellaObject = {
     videoIdentifier: 'the-video-identifier',
     videoContainer: {
       currentTime: mockCurrentTime,
-      trimStart: mockTrimStart
+      trimStart: mockTrimStart,
+      paused: mockPaused
     }
   },
   matterhorn: {
@@ -26,7 +27,7 @@ var mockPaellaObject = {
 };
 
 test('Heartbeat tests', function heartbeatTests(t) {
-  t.plan(13);
+  t.plan(14);
 
   // Set up mocks and checks.
   setUpMocks();
@@ -113,6 +114,12 @@ function setUpAssertingMocks(t) {
       'object',
       'The timestamp ("_") query param is a valid date.'
     );
+
+    t.equal(
+      query.playing,
+      'true',
+      'The playing query param should be set to the string "true".'
+    );
   }
 }
 
@@ -163,3 +170,6 @@ function mockTrimStart() {
   return 200;
 }
 
+function mockPaused() {
+  return false;
+}

--- a/vendor/plugins/edu.harvard.dce.paella.heartbeatSender/heartbeat_sender.js
+++ b/vendor/plugins/edu.harvard.dce.paella.heartbeatSender/heartbeat_sender.js
@@ -1,7 +1,7 @@
 // A version of the deprecated es.upv.paella.UserTrackingCollectorPlugIn, 
 // shaved down to just send the heartbeat.
 
-var classDef = {
+var heartbeatSenderClassDef = {
   heartbeatTimer:null,
 
   getName: function() {
@@ -63,6 +63,10 @@ var classDef = {
   }
 };
 
-Class("paella.plugins.HeartbeatSender", paella.EventDrivenPlugin, classDef);
+Class(
+  "paella.plugins.HeartbeatSender",
+  paella.EventDrivenPlugin,
+  heartbeatSenderClassDef
+);
 
 paella.plugins.heartbeatSender = new paella.plugins.HeartbeatSender();

--- a/vendor/plugins/edu.harvard.dce.paella.heartbeatSender/heartbeat_sender.js
+++ b/vendor/plugins/edu.harvard.dce.paella.heartbeatSender/heartbeat_sender.js
@@ -51,7 +51,7 @@ var classDef = {
 
     function queryStringFromDict(dict) {
       var qs = '';
-      for (key in dict) {
+      for (var key in dict) {
         if (qs.length > 0) {
           qs += '&';
         }

--- a/vendor/plugins/edu.harvard.dce.paella.heartbeatSender/heartbeat_sender.js
+++ b/vendor/plugins/edu.harvard.dce.paella.heartbeatSender/heartbeat_sender.js
@@ -19,7 +19,39 @@ var classDef = {
     }
 
     function registerHeartbeat(timer) {
-      thisClass.registerEvent('HEARTBEAT'); 
+      // thisClass.registerEvent('HEARTBEAT'); 
+      var xhr = new XMLHttpRequest();
+      xhr.open('GET', getHeartbeatURL());
+    }
+
+    function getHeartbeatURL() {
+      var url = 'https://';
+      url += location.host + '/';
+      url += 'usertracking/?';
+      url += queryStringFromDict({
+        _method: 'PUT',
+        id: paella.player.videoIdentifier,
+        type: 'HEARTBEAT',
+        in: 0,
+        out: 0,
+        playing: false,
+        resource: paella.matterhorn.resourceId,
+        _: 1441381319430
+      });
+
+      // https://localhost:3000/_method=PUT&id=74b6c02f-afbb-42bc-8145-344153a1792e&type=HEARTBEAT&in=0&out=0&playing=false&resource=%2F2015%2F03%2F33383%2FL10&_=1441381319430'
+      return url;
+    }
+
+    function queryStringFromDict(dict) {
+      var qs = '';
+      for (key in dict) {
+        if (qs.length > 0) {
+          qs += '&';
+        }
+        qs += key + '=' + encodeURIComponent(dict[key]);
+      }
+      return qs;
     }
   }
 };

--- a/vendor/plugins/edu.harvard.dce.paella.heartbeatSender/heartbeat_sender.js
+++ b/vendor/plugins/edu.harvard.dce.paella.heartbeatSender/heartbeat_sender.js
@@ -1,0 +1,29 @@
+// A version of the deprecated es.upv.paella.UserTrackingCollectorPlugIn, 
+// shaved down to just send the heartbeat.
+
+var classDef = {
+  heartbeatTimer:null,
+
+  getName: function() {
+    return "edu.harvard.dce.paella.heartbeatSender";
+  },
+
+  setup: function() {
+    var thisClass = this;
+  
+    if (this.config.heartBeatTime > 0) {
+      this.heartbeatTimer = new base.Timer(
+        registerHeartbeat, this.config.heartBeatTime
+      );
+      this.heartbeatTimer.repeat = true;
+    }
+
+    function registerHeartbeat(timer) {
+      thisClass.registerEvent('HEARTBEAT'); 
+    }
+  }
+};
+
+Class("paella.plugins.HeartbeatSender", paella.EventDrivenPlugin, classDef);
+
+paella.plugins.heartbeatSender = new paella.plugins.HeartbeatSender();

--- a/vendor/plugins/edu.harvard.dce.paella.heartbeatSender/heartbeat_sender.js
+++ b/vendor/plugins/edu.harvard.dce.paella.heartbeatSender/heartbeat_sender.js
@@ -1,72 +1,73 @@
 // A version of the deprecated es.upv.paella.UserTrackingCollectorPlugIn, 
 // shaved down to just send the heartbeat.
 
-var heartbeatSenderClassDef = {
-  heartbeatTimer:null,
-
-  getName: function() {
-    return "edu.harvard.dce.paella.heartbeatSender";
-  },
-
-  setup: function() {
-    var thisClass = this;
-  
-    if (this.config.heartBeatTime > 0) {
-      this.heartbeatTimer = new base.Timer(
-        registerHeartbeat, this.config.heartBeatTime
-      );
-      this.heartbeatTimer.repeat = true;
-    }
-
-    function registerHeartbeat(timer) {
-      var xhr = new XMLHttpRequest();
-      xhr.open('GET', getHeartbeatURL());
-      xhr.send();
-    }
-
-    function getHeartbeatURL() {
-      var videoCurrentTime = parseInt(
-        paella.player.videoContainer.currentTime() +
-        paella.player.videoContainer.trimStart(),
-        10
-      );
-
-      var url = 'https://';
-      url += location.host + '/';
-      url += 'usertracking/?';
-      url += queryStringFromDict({
-        _method: 'PUT',
-        id: paella.player.videoIdentifier,
-        type: 'HEARTBEAT',
-        in: videoCurrentTime,
-        out: videoCurrentTime,
-        playing: !paella.player.videoContainer.paused(),
-        resource: paella.matterhorn.resourceId,
-        _: (new Date()).getTime()
-      });
-
-      // Example heartbeat URL:
-      // https://localhost:3000/_method=PUT&id=74b6c02f-afbb-42bc-8145-344153a1792e&type=HEARTBEAT&in=0&out=0&playing=false&resource=%2F2015%2F03%2F33383%2FL10&_=1441381319430'
-      return url;
-    }
-
-    function queryStringFromDict(dict) {
-      var qs = '';
-      for (var key in dict) {
-        if (qs.length > 0) {
-          qs += '&';
-        }
-        qs += key + '=' + encodeURIComponent(dict[key]);
-      }
-      return qs;
-    }
-  }
-};
-
 Class(
   "paella.plugins.HeartbeatSender",
   paella.EventDrivenPlugin,
-  heartbeatSenderClassDef
-);
+
+  // Start class definition.
+  {
+    heartbeatTimer:null,
+
+    getName: function() {
+      return "edu.harvard.dce.paella.heartbeatSender";
+    },
+
+    setup: function() {
+      var thisClass = this;
+    
+      if (this.config.heartBeatTime > 0) {
+        this.heartbeatTimer = new base.Timer(
+          registerHeartbeat, this.config.heartBeatTime
+        );
+        this.heartbeatTimer.repeat = true;
+      }
+
+      function registerHeartbeat(timer) {
+        var xhr = new XMLHttpRequest();
+        xhr.open('GET', getHeartbeatURL());
+        xhr.send();
+      }
+
+      function getHeartbeatURL() {
+        var videoCurrentTime = parseInt(
+          paella.player.videoContainer.currentTime() +
+          paella.player.videoContainer.trimStart(),
+          10
+        );
+
+        var url = 'https://';
+        url += location.host + '/';
+        url += 'usertracking/?';
+        url += queryStringFromDict({
+          _method: 'PUT',
+          id: paella.player.videoIdentifier,
+          type: 'HEARTBEAT',
+          in: videoCurrentTime,
+          out: videoCurrentTime,
+          playing: !paella.player.videoContainer.paused(),
+          resource: paella.matterhorn.resourceId,
+          _: (new Date()).getTime()
+        });
+
+        // Example heartbeat URL:
+        // https://localhost:3000/_method=PUT&id=74b6c02f-afbb-42bc-8145-344153a1792e&type=HEARTBEAT&in=0&out=0&playing=false&resource=%2F2015%2F03%2F33383%2FL10&_=1441381319430'
+        return url;
+      }
+
+      function queryStringFromDict(dict) {
+        var qs = '';
+        for (var key in dict) {
+          if (qs.length > 0) {
+            qs += '&';
+          }
+          qs += key + '=' + encodeURIComponent(dict[key]);
+        }
+        return qs;
+      }
+    }
+  }
+  // End class definition.
+});
 
 paella.plugins.heartbeatSender = new paella.plugins.HeartbeatSender();

--- a/vendor/plugins/edu.harvard.dce.paella.heartbeatSender/heartbeat_sender.js
+++ b/vendor/plugins/edu.harvard.dce.paella.heartbeatSender/heartbeat_sender.js
@@ -19,7 +19,6 @@ var classDef = {
     }
 
     function registerHeartbeat(timer) {
-      // thisClass.registerEvent('HEARTBEAT'); 
       var xhr = new XMLHttpRequest();
       xhr.open('GET', getHeartbeatURL());
     }
@@ -42,9 +41,10 @@ var classDef = {
         out: videoCurrentTime,
         playing: false,
         resource: paella.matterhorn.resourceId,
-        _: 1441381319430
+        _: (new Date()).getTime()
       });
 
+      // Example heartbeat URL:
       // https://localhost:3000/_method=PUT&id=74b6c02f-afbb-42bc-8145-344153a1792e&type=HEARTBEAT&in=0&out=0&playing=false&resource=%2F2015%2F03%2F33383%2FL10&_=1441381319430'
       return url;
     }

--- a/vendor/plugins/edu.harvard.dce.paella.heartbeatSender/heartbeat_sender.js
+++ b/vendor/plugins/edu.harvard.dce.paella.heartbeatSender/heartbeat_sender.js
@@ -21,6 +21,7 @@ var classDef = {
     function registerHeartbeat(timer) {
       var xhr = new XMLHttpRequest();
       xhr.open('GET', getHeartbeatURL());
+      xhr.send();
     }
 
     function getHeartbeatURL() {

--- a/vendor/plugins/edu.harvard.dce.paella.heartbeatSender/heartbeat_sender.js
+++ b/vendor/plugins/edu.harvard.dce.paella.heartbeatSender/heartbeat_sender.js
@@ -25,6 +25,12 @@ var classDef = {
     }
 
     function getHeartbeatURL() {
+      var videoCurrentTime = parseInt(
+        paella.player.videoContainer.currentTime() +
+        paella.player.videoContainer.trimStart(),
+        10
+      );
+
       var url = 'https://';
       url += location.host + '/';
       url += 'usertracking/?';
@@ -32,8 +38,8 @@ var classDef = {
         _method: 'PUT',
         id: paella.player.videoIdentifier,
         type: 'HEARTBEAT',
-        in: 0,
-        out: 0,
+        in: videoCurrentTime,
+        out: videoCurrentTime,
         playing: false,
         resource: paella.matterhorn.resourceId,
         _: 1441381319430

--- a/vendor/plugins/edu.harvard.dce.paella.heartbeatSender/heartbeat_sender.js
+++ b/vendor/plugins/edu.harvard.dce.paella.heartbeatSender/heartbeat_sender.js
@@ -39,7 +39,7 @@ var classDef = {
         type: 'HEARTBEAT',
         in: videoCurrentTime,
         out: videoCurrentTime,
-        playing: false,
+        playing: !paella.player.videoContainer.paused(),
         resource: paella.matterhorn.resourceId,
         _: (new Date()).getTime()
       });

--- a/vendor/plugins/edu.harvard.dce.paella.heartbeatSender/heartbeat_sender.js
+++ b/vendor/plugins/edu.harvard.dce.paella.heartbeatSender/heartbeat_sender.js
@@ -68,6 +68,6 @@ Class(
     }
   }
   // End class definition.
-});
+);
 
 paella.plugins.heartbeatSender = new paella.plugins.HeartbeatSender();


### PR DESCRIPTION
Added a heartbeat plugin that is a simplified version of the es.upv.paella.UserTrackingCollectorPlugin from Paella 3.x. (Which no longer exists in current upstream paella or paella-matterhorn, but we still need it for our fork of Matterhorn.)

Added tests for it using [tape](https://github.com/substack/tape). Because this plugin architecture wasn't built with testing in mind, there is quite a bit of mocking that had to happen. I can walk you through the mocks in person if you'd like.