### PR TITLE
Livestream heartbeat

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "call-next-tick": "^1.1.2",
     "lodash": "^3.10.1",
+    "require-reload": "^0.2.2",
     "tape": "^4.2.0"
   },
   "dependencies": {}

--- a/tests/heartbeat-sender-tests.js
+++ b/tests/heartbeat-sender-tests.js
@@ -2,10 +2,11 @@ var test = require('tape');
 var _ = require('lodash');
 var callNextTick = require('call-next-tick');
 var url = require('url');
+var reload = require('require-reload')(require);
 
-// !! These tests require global mocks. If they need to be run in the same  
-// process as another test in the future, teardowns need to be added.
+var modulePath = '../vendor/plugins/edu.harvard.dce.paella.heartbeatSender/heartbeat_sender';
 
+// !! These tests require global mocks.
 var mockConfig = {
   heartBeatTime: 100          
 };
@@ -33,16 +34,36 @@ test('Heartbeat tests', function heartbeatTests(t) {
   setUpMocks();
   setUpAssertingMocks(t);
 
-
   // Loading the plugin code actually executes the plugin.
   // That is how Paella plugins work.
-  require('../vendor/plugins/edu.harvard.dce.paella.heartbeatSender/heartbeat_sender');
+  require(modulePath);
 
 });
 
+test('Livestream heartbeat test', function liveStreamTest(t) {
+  tearDownGlobals();
+  
+  t.plan(15);
+
+  setUpMocks();
+  setUpAssertingMocks(t);
+
+  // For a live stream, paella.player.paused() will always return true, even if 
+  // it is playing (which it always is).
+  paella.player.isLiveStream = function mockIsLiveStream() {
+    return true;
+  };
+  paella.player.videoContainer.paused = mockPausedIsTrue;
+
+  reload(modulePath);
+});
+
+
+// TODO: Separate mocks and asserts.
+
 function setUpAssertingMocks(t) {
   global.base.Timer = timer;
-  global.XMLHttpRequest = mockXHR;
+  global.XMLHttpRequest = createMockXHR();
 
   function timer(callback, time, params) {
     t.equal(
@@ -66,19 +87,29 @@ function setUpAssertingMocks(t) {
     }
   }
 
-  function mockXHR() {
-    this.open = mockOpen;
-    this.send = mockSend;
+  function createMockXHR() {
+    function mockXHR() {
+      debugger;
+      this.open = createMockOpen();
+      this.send = createMockSend();
+    }
+    return mockXHR;
   }
 
-  function mockOpen(method, URL) {
-    t.equal(method, 'GET', 'Opens a request with the GET method.');
-    // t.equal(URL, )
-    checkHeartbeatURL(URL);
+  function createMockOpen() {
+    function mockOpen(method, URL) {
+      t.equal(method, 'GET', 'Opens a request with the GET method.');
+      // t.equal(URL, )
+      checkHeartbeatURL(URL);
+    }
+    return mockOpen;
   }
 
-  function mockSend() {
-    t.pass('The xhr is actually sent.');
+  function createMockSend() {
+    function mockSend() {
+      t.pass('The xhr is actually sent.');
+    }
+    return mockSend;
   }
 
   function checkHeartbeatURL(URL) {
@@ -137,6 +168,7 @@ function setUpAssertingMocks(t) {
 //  }
 // }
 function setUpMocks(opts) {
+
   global.location = {
     host: 'test-server'
   };
@@ -177,4 +209,17 @@ function mockTrimStart() {
 
 function mockPaused() {
   return false;
+}
+
+function mockPausedIsTrue() {
+  console.log('this was called.')
+  return true;
+}
+
+function tearDownGlobals() {
+  delete global.location;
+  delete global.paella;
+  delete global.base;
+  delete global.Class;  
+  delete global.XMLHttpRequest;
 }

--- a/tests/heartbeat-sender-tests.js
+++ b/tests/heartbeat-sender-tests.js
@@ -212,7 +212,6 @@ function mockPaused() {
 }
 
 function mockPausedIsTrue() {
-  console.log('this was called.')
   return true;
 }
 

--- a/vendor/plugins/edu.harvard.dce.paella.heartbeatSender/heartbeat_sender.js
+++ b/vendor/plugins/edu.harvard.dce.paella.heartbeatSender/heartbeat_sender.js
@@ -36,6 +36,15 @@ Class(
           10
         );
 
+        // In the case of a live stream and a config setting that says to not 
+        // play on load, paella.player.videoContainer.paused() will always 
+        // return true, so it's not reliable then.
+        // However, our live stream player does not allow pausing. If you are 
+        // watching live stream, you are playing. So, we can count on that to 
+        // determine play state.
+        var isPlaying = !paella.player.videoContainer.paused() ||
+          paella.player.isLiveStream();
+
         var url = 'https://';
         url += location.host + '/';
         url += 'usertracking/?';
@@ -45,7 +54,7 @@ Class(
           type: 'HEARTBEAT',
           in: videoCurrentTime,
           out: videoCurrentTime,
-          playing: !paella.player.videoContainer.paused(),
+          playing: isPlaying,
           resource: paella.matterhorn.resourceId,
           _: (new Date()).getTime()
         });


### PR DESCRIPTION
Fix for  MATT-1621: In the case of a live stream, isPlaying is not set correctly in the heartbeat request.

In the case of a live stream and a config setting that says to not play on load, `paella.player.videoContainer.paused()` will always return true, so it's not reliable then.

However, our live stream player does not allow pausing. If you are watching a live stream, you are playing. So, we are now using that to determine play state for live streams.