### PR TITLE
T/matt 1828 start end params

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -64,7 +64,10 @@
         "enabled": false,
         "alwaysVisible": false
       },
-      "es.upv.paella.TrimmingPlayerPlugin": {
+      "edu.harvard.dce.paella.trimmingPlayerPlugin": {
+        "enabled": true
+      },
+      "es.upv.paella.trimmingPlayerPlugin": {
         "enabled": false
       },
       "es.upv.paella.editor.TrimmingTrackPlugin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dce-paella-extensions",
-  "version": "1.1.31",
+  "version": "1.1.32",
   "description": "Harvard DCE Extensions for the Paella video player",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dce-paella-extensions",
-  "version": "1.1.30",
+  "version": "1.1.31",
   "description": "Harvard DCE Extensions for the Paella video player",
   "main": "index.js",
   "scripts": {

--- a/vendor/plugins/edu.harvard.dce.paella.TrimmingPlugins/localization/es.json
+++ b/vendor/plugins/edu.harvard.dce.paella.TrimmingPlugins/localization/es.json
@@ -1,0 +1,3 @@
+{
+	"Trimming": "Ajuste de inicio y fin"
+}

--- a/vendor/plugins/edu.harvard.dce.paella.TrimmingPlugins/trimming_player.js
+++ b/vendor/plugins/edu.harvard.dce.paella.TrimmingPlugins/trimming_player.js
@@ -1,0 +1,46 @@
+// #DCE MATT-1828, modified es.upv.paella.trimmingPlayerPlugin
+// to enable getting start and stop from the location args in addition to trimming
+Class ("paella.plugins.TrimmingLoaderPlugin",paella.EventDrivenPlugin,{
+
+	getName:function() { return "edu.harvard.dce.paella.trimmingPlayerPlugin"; },
+
+	getEvents:function() { return [paella.events.controlBarLoaded, paella.events.showEditor, paella.events.hideEditor]; },
+
+	onEvent:function(eventType,params) {
+		switch (eventType) {
+			case paella.events.controlBarLoaded:
+				this.loadTrimming();
+				break;
+			case paella.events.showEditor:
+				paella.player.videoContainer.disableTrimming();
+				break;
+			case paella.events.hideEditor:
+				if (paella.player.config.trimming && paella.player.config.trimming.enabled) {
+					paella.player.videoContainer.enableTrimming();
+				}
+				break;
+		}
+	},
+
+	loadTrimming:function() {
+		var videoId = paella.initDelegate.getId();
+		paella.data.read('trimming',{id:videoId},function(data,status) {
+			if (data && status && data.end>0) {
+				paella.player.videoContainer.enableTrimming();
+				paella.player.videoContainer.setTrimming(data.start, data.end);
+			} else {
+			    // #DCE MATT-1828 look for start and end trim times in location args
+			    // trimming:{enabled:false,start:0,end:0}
+			    var startTime =  paella.utils.parameters.get('start');
+			    var endTime = paella.utils.parameters.get('end');
+			    if (startTime && endTime) {
+			        paella.player.videoContainer.enableTrimming();
+				    paella.player.videoContainer.setTrimming(startTime, endTime);
+			    }
+			}
+			// #end DCE
+		});
+	}
+});
+
+paella.plugins.trimmingLoaderPlugin = new paella.plugins.TrimmingLoaderPlugin();


### PR DESCRIPTION
This is the UPV Paella's existing trim load player, but optionally looking for start and end params in the URL args. UPV Paella builds in trim start and end time handling in it's other plugins, so it seems to behave well. There is an oddity with the hover time over the start side of the playbar, but the playbar shows the correct trimmed time. 