### PR TITLE
MATT-2031 use relative url for heartbeat request

### DIFF
--- a/tests/heartbeat-sender-tests.js
+++ b/tests/heartbeat-sender-tests.js
@@ -8,7 +8,7 @@ var modulePath = '../vendor/plugins/edu.harvard.dce.paella.heartbeatSender/heart
 
 // !! These tests require global mocks.
 var mockConfig = {
-  heartBeatTime: 100          
+  heartBeatTime: 100
 };
 
 var mockPaellaObject = {
@@ -28,7 +28,7 @@ var mockPaellaObject = {
 };
 
 test('Heartbeat tests', function heartbeatTests(t) {
-  t.plan(15);
+  t.plan(14);
 
   // Set up mocks and checks.
   setUpMocks();
@@ -42,13 +42,13 @@ test('Heartbeat tests', function heartbeatTests(t) {
 
 test('Livestream heartbeat test', function liveStreamTest(t) {
   tearDownGlobals();
-  
-  t.plan(15);
+
+  t.plan(14);
 
   setUpMocks();
   setUpAssertingMocks(t);
 
-  // For a live stream, paella.player.paused() will always return true, even if 
+  // For a live stream, paella.player.paused() will always return true, even if
   // it is playing (which it always is).
   paella.player.isLiveStream = function mockIsLiveStream() {
     return true;
@@ -116,7 +116,6 @@ function setUpAssertingMocks(t) {
     var urlParts = url.parse(URL, true);
     var query = urlParts.query;
 
-    t.equal(urlParts.protocol, 'https:', 'Request is sent via https.');
     t.equal(urlParts.pathname, '/usertracking/', 'Request pathname is correct.');
 
     t.equal(
@@ -185,7 +184,7 @@ function setUpMocks(opts) {
 
     function createClass() {
       var classInst = _.cloneDeep(classDef);
-      classInst.config = _.cloneDeep(mockConfig);      
+      classInst.config = _.cloneDeep(mockConfig);
       classInst.setup();
 
       if (opts && opts.classMethods) {
@@ -219,6 +218,6 @@ function tearDownGlobals() {
   delete global.location;
   delete global.paella;
   delete global.base;
-  delete global.Class;  
+  delete global.Class;
   delete global.XMLHttpRequest;
 }

--- a/vendor/plugins/edu.harvard.dce.paella.heartbeatSender/heartbeat_sender.js
+++ b/vendor/plugins/edu.harvard.dce.paella.heartbeatSender/heartbeat_sender.js
@@ -1,4 +1,4 @@
-// A version of the deprecated es.upv.paella.UserTrackingCollectorPlugIn, 
+// A version of the deprecated es.upv.paella.UserTrackingCollectorPlugIn,
 // shaved down to just send the heartbeat.
 
 Class(
@@ -15,7 +15,7 @@ Class(
 
     setup: function() {
       var thisClass = this;
-    
+
       if (this.config.heartBeatTime > 0) {
         this.heartbeatTimer = new base.Timer(
           registerHeartbeat, this.config.heartBeatTime
@@ -36,18 +36,16 @@ Class(
           10
         );
 
-        // In the case of a live stream and a config setting that says to not 
-        // play on load, paella.player.videoContainer.paused() will always 
+        // In the case of a live stream and a config setting that says to not
+        // play on load, paella.player.videoContainer.paused() will always
         // return true, so it's not reliable then.
-        // However, our live stream player does not allow pausing. If you are 
-        // watching live stream, you are playing. So, we can count on that to 
+        // However, our live stream player does not allow pausing. If you are
+        // watching live stream, you are playing. So, we can count on that to
         // determine play state.
         var isPlaying = !paella.player.videoContainer.paused() ||
           paella.player.isLiveStream();
 
-        var url = 'https://';
-        url += location.host + '/';
-        url += 'usertracking/?';
+        var url = '/usertracking/?';
         url += queryStringFromDict({
           _method: 'PUT',
           id: paella.player.videoIdentifier,


### PR DESCRIPTION
Sorry for the whitespace changes. Blame Atom. This just modifies the heartbeat url assemble to skip the scheme and host and just use relative urls. This is how the upstream [usertracking plugin](https://github.com/harvard-dce/paella-matterhorn/blob/master/paella-matterhorn/plugins/es.upv.paella.matterhorn.userTrackingSaverPlugIn/mh_usertracking_saver.js) does it to avoid cross-content http vs https issues.