### PR TITLE
MATT-1941 match config to paella to prevent dualing audio

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -3,6 +3,7 @@
   "player": {
     "defaultProfile": "full",
     "profileFrameStrategy": "paella.ProfileFrameStrategy",
+    "videoQualityStrategy": "paella.BestFitVideoQualityStrategy",
     "methods": [
       {
         "name": "streaming",
@@ -21,10 +22,13 @@
         "enabled": true
       }
     ],
-    "stream0Audio": true,
-    "stream1Audio": false,
+    "audio": {
+        "master": 1.0,
+        "slave": 0.0
+    },
     "rtmpSettings": {
-      "bufferTime": 5
+      "bufferTime": 5,
+      "requiresSubscription": false
     }
   },
   "editor": {
@@ -41,6 +45,7 @@
     }
   },
   "plugins": {
+    "enablePluginsByDefault": false,
     "defaultConfig": {
       "enabled": true
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dce-paella-extensions",
-  "version": "1.2.40",
+  "version": "1.2.41",
   "description": "Harvard DCE Extensions for the Paella video player",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dce-paella-extensions",
-  "version": "1.2.41",
+  "version": "1.2.43",
   "description": "Harvard DCE Extensions for the Paella video player",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This aligns the extensions config with the paella version, in particular, the change in param strategy on the audio muting. 