### PR TITLE
MATT-2217 disable 2 plugins when loaded on iphone

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -217,6 +217,10 @@
       },
       "es.upv.paella.captions.DFXPParserPlugin": {
         "enabled": true
+      },
+      "edu.harvard.dce.paella.iphonePluginDisablerPlugin": {
+        "enabled": true,
+        "actiondelay":200
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dce-paella-extensions",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "description": "Harvard DCE Extensions for the Paella video player",
   "main": "index.js",
   "scripts": {

--- a/vendor/plugins/edu.harvard.dce.paella.iphonePluginDisablerPlugin/iphone-plugin-disabler.js
+++ b/vendor/plugins/edu.harvard.dce.paella.iphonePluginDisablerPlugin/iphone-plugin-disabler.js
@@ -1,0 +1,40 @@
+// MATT-2217 #DCE disable fullscreen & slide frame plugin on iPhone device
+// This plugin waits 200ms (changed via config) after the "loadPlugins" event before
+// overriding the only param that can disable a UPV plugin after it's been loaded (its default min window size). 
+Class (
+"paella.plugins.IphonePluginDisablerPlugin", paella.EventDrivenPlugin, {
+  _actiondelay: 200,
+  setup: function () {
+    // override the default via config
+    this._actiondelay = this.config.actiondelay || this._actiondelay;
+  },
+  getName: function () {
+    return "edu.harvard.dce.paella.iphonePluginDisablerPlugin";
+  },
+  
+  getEvents: function () {
+    return[paella.events.loadPlugins];
+  },
+  
+  onEvent: function (event, params) {
+    this.disable();
+  },
+  checkEnabled: function (onSuccess) {
+    onSuccess(navigator.userAgent.match(/(iPhone)/g));
+  },
+  
+  disable: function () {
+    window.setTimeout(function () {
+      // Not a fan, but need to give plugins a chance to load before overriding the attributes.
+      paella.plugins.fullScreenPlugin.getMinWindowSize = function () {
+        return 10000;
+      }
+      paella.plugins.frameControlPlugin.getMinWindowSize = function () {
+        return 10000;
+      }
+    },
+    200);
+  }
+});
+
+paella.plugins.iphonePluginDisablerPlugin = new paella.plugins.IphonePluginDisablerPlugin();


### PR DESCRIPTION
Plugin to disable 2 default UPV plugins when running on an iphone device (Jody's request)