### PR TITLE
MATT-2219 add CC disclaimer when no transcription text found

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dce-paella-extensions",
-  "version": "1.6.9",
+  "version": "1.6.10",
   "description": "Harvard DCE Extensions for the Paella video player",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This updates the closed caption/transcription UI to post a disclaimer and prevent the grey box over the video when a transcription is performed over a wordless video and Watson can find no words in the audio.

The UI has passed manager approval. The plugin is going through official QA (has already been verified in local testing)