### PR TITLE
MATT-2192 magic fix to enable control bar after Safari 10.0.1 exitFullScreen

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -224,6 +224,9 @@
       "edu.harvard.dce.paella.iphonePluginDisablerPlugin": {
         "enabled": true,
         "actiondelay":200
+      },
+      "edu.harvard.dce.safari10ExitFullScreenControlBarMagicFix": {
+        "enabled": true
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dce-paella-extensions",
-  "version": "1.6.12",
+  "version": "1.6.13",
   "description": "Harvard DCE Extensions for the Paella video player",
   "main": "index.js",
   "scripts": {

--- a/vendor/plugins/edu.harvard.dce.paella.safari10FsExitControlBarMagicFix/safari10exitFullscreenMagicFix.js
+++ b/vendor/plugins/edu.harvard.dce.paella.safari10FsExitControlBarMagicFix/safari10exitFullscreenMagicFix.js
@@ -1,0 +1,35 @@
+// MATT-2192 Safari version 10.0.1 control bar disappears after exiting full. This is temp fix (bug was submitted via Apple developer)
+Class ("paella.plugins.safari10ExitFullScreenControlBarMagicFix", paella.EventDrivenPlugin, {
+
+	getName:function() { return "edu.harvard.dce.safari10ExitFullScreenControlBarMagicFix"; },
+	getEvents:function() { return [paella.events.exitFullscreen]; },
+	onEvent:function(eventType,params) {
+	    this.magicFix();
+	},
+
+	checkEnabled: function(onSuccess) {
+		// Only for Safari
+		if (base.userAgent.browser.Safari) {
+			onSuccess(true);
+		} else {
+			onSuccess(false);
+		}
+	},
+
+	magicFix: function(){
+		if ($("#playerContainer_controls").length == 0) return;
+		var self = this;
+		var randomSmallMaxHeight = "6px";
+		var safariMagicDelayInMs = 1000;
+		var maxHeightOrig = $("#playerContainer_controls").css("max-height");
+		$("#playerContainer_controls").css({"max-height": randomSmallMaxHeight});
+		// Do the magic pause!
+		setTimeout(function() { self.resetMaxHeight(maxHeightOrig); }, safariMagicDelayInMs);
+	},
+
+	resetMaxHeight: function(maxHeightOrig) {
+		$("#playerContainer_controls").css({"max-height": maxHeightOrig });
+	}
+});
+
+new paella.plugins.safari10ExitFullScreenControlBarMagicFix();


### PR DESCRIPTION
MATT-2192 magic fix to enable control bar after Safari 10.0.1 exitFullScreen. There is a ticket to Apple Safari about this. The control bar is not accessible (although showing CSS visible, etc) after exiting full screen in  Safari 10.0.1. This does not happen in Safari 9x, only after the Safari 10 upgrade. 

Until I get more detail from Apple, adding this tiny delay then kicking the CSS on the control bar corrects the issue. 