### PR TITLE
send `&playing=live` for live stream events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 node_modules
+npm-debug.log

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dce-paella-extensions",
-  "version": "1.6.16",
+  "version": "1.6.17",
   "description": "Harvard DCE Extensions for the Paella video player",
   "main": "index.js",
   "scripts": {
@@ -18,7 +18,7 @@
   "author": "Harvard DCE",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/jimkang/dce-paella-extensions/issues"
+    "url": "https://github.com/harvard-dce/dce-paella-extensions/issues"
   },
   "homepage": "https://github.com/harvard-dce/dce-paella-extensions",
   "devDependencies": {

--- a/tests/heartbeat-sender-tests.js
+++ b/tests/heartbeat-sender-tests.js
@@ -54,13 +54,6 @@ test('Livestream heartbeat test', function liveStreamTest(t) {
   setUpMocks();
   setUpAssertingMocks(t);
 
-  // For a live stream, paella.player.paused() will always return true, even if
-  // it is playing (which it always is).
-  paella.player.isLiveStream = function mockIsLiveStream() {
-    return true;
-  };
-  paella.player.videoContainer.paused = mockPausedIsTrue;
-
   reload(modulePath);
 });
 
@@ -159,7 +152,7 @@ function setUpAssertingMocks(t) {
 
     t.equal(
       query.playing,
-      'true',
+      'live',
       'The playing query param should be set to the string "true".'
     );
   }
@@ -180,6 +173,12 @@ function setUpMocks(opts) {
   };
 
   global.paella = _.cloneDeep(mockPaellaObject);
+
+  // For a live stream, paella.player.paused() will always return true, even if
+  // it is playing (which it always is).
+  global.paella.player.isLiveStream = mockIsLiveStream;
+  global.paella.player.videoContainer.paused = mockPausedIsTrue;
+
 
   global.base = {};
 
@@ -218,6 +217,10 @@ function mockPaused() {
 }
 
 function mockPausedIsTrue() {
+  return true;
+}
+
+function mockIsLiveStream() {
   return true;
 }
 

--- a/vendor/plugins/edu.harvard.dce.paella.heartbeatSender/heartbeat_sender.js
+++ b/vendor/plugins/edu.harvard.dce.paella.heartbeatSender/heartbeat_sender.js
@@ -40,8 +40,7 @@ Class(
         // However, our live stream player does not allow pausing. If you are
         // watching live stream, you are playing. So, we can count on that to
         // determine play state.
-        var isPlaying = !videoData.paused ||
-          paella.player.isLiveStream();
+        var isPlaying = paella.player.isLiveStream() ? "live" : (!videoData.paused).toString();
 
         var url = '/usertracking/?';
         url += queryStringFromDict({

--- a/vendor/skins/cs50.less
+++ b/vendor/skins/cs50.less
@@ -35,9 +35,8 @@
 
 @playbackBarFontSize: 12px;
 
-
 body {
-    background-color: #333;
+  background-color: #333;
 }
 
 .buttonPlugin {


### PR DESCRIPTION
This also includes a non-change change to `vendor/skins/cs50.less`. After updating to the latest grunt-contrib-* modules there was something about the whitespace formatting for that `body` block that was causing invalid input errors, maybe a tab character, idk.