### PR TITLE
MATT-2467 RequestedOrBestFitVideoQualityStrategy to use URL param res

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -3,7 +3,7 @@
   "player": {
     "defaultProfile": "full",
     "profileFrameStrategy": "paella.ProfileFrameStrategy",
-    "videoQualityStrategy": "paella.BestFitVideoQualityStrategy",
+    "videoQualityStrategy": "paella.RequestedOrBestFitVideoQualityStrategy",
     "methods": [
         { "factory":"MpegDashVideoFactory", "enabled":true },
         { "factory":"Html5VideoFactory", "enabled":true },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dce-paella-extensions",
-  "version": "1.6.18",
+  "version": "1.6.19",
   "description": "Harvard DCE Extensions for the Paella video player",
   "main": "index.js",
   "scripts": {

--- a/vendor/plugins/edu.harvard.dce.paella.requestedOrBestFitVideoQualityStrategy/requestedOrBestFitVideoQualityStrategy.js
+++ b/vendor/plugins/edu.harvard.dce.paella.requestedOrBestFitVideoQualityStrategy/requestedOrBestFitVideoQualityStrategy.js
@@ -1,0 +1,50 @@
+// #DCE MATT-2467 retrieve resolution from param or fallback to best fit strategy
+Class ("paella.RequestedOrBestFitVideoQualityStrategy", paella.VideoQualityStrategy, {
+    
+    // From the UPV BestFitVideoQualityStrategy
+    getBestFit: function (source, index) {
+        var selected = source[0];
+        var win_w = $(window).width();
+        var win_h = $(window).height();
+        var win_res = (win_w * win_h);
+        if (selected.res && selected.res.w && selected.res.h) {
+            var selected_res = parseInt(selected.res.w) * parseInt(selected.res.h);
+            var selected_diff = Math.abs(win_res - selected_res);
+            
+            for (var i = 0; i < source.length;++ i) {
+                var res = source[i].res;
+                if (res) {
+                    var m_res = parseInt(source[i].res.w) * parseInt(source[i].res.h);
+                    var m_diff = Math.abs(win_res - m_res);
+                    
+                    if (m_diff <= selected_diff) {
+                        selected_diff = m_diff;
+                        index = i;
+                    }
+                }
+            }
+        }
+        return index;
+    },
+    getQualityIndex: function (source) {
+        var index = source.length - 1;
+        var requestedResolution = base.parameters.get('res');
+        if (source.length > 0) {
+            switch (requestedResolution) {
+                case "high":
+                    index = source.length - 1;
+                    break;
+                case "medium":
+                     // takes medium res or the lower of 2 medium res (i.e. if only 2 res, high and low, it takes the low)
+                     index = (source.length % 2 === 0? (source.length/2) - 1: (source.length - 1)/2);
+                     break;
+                case "low":
+                     index = 0;
+                     break;
+                default:
+                    index = this.getBestFit (source, index);
+            }
+        }
+        return index;
+    }
+});


### PR DESCRIPTION
The "res" param value can be "high", "low", "med". If no res value, or the res value is not one of those three, the  fallback is to the regular default of UPV's BestFitQuality strategy.

The source is already sorted from low res to high res by the caller (the video contain's video object) before it is passed into the getQualityIndex() method.