### PR TITLE
OPC-78 configurable social tool admin groups

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -170,7 +170,11 @@
         "enabled": true
       },
       "edu.harvard.dce.paella.timedCommentsOverlayPlugin": {
-        "enabled": true
+        "enabled": true,
+        "adminRoles": [
+           "ROLE_ADMIN",
+           "ROLE_DCE_OC_SOCIAL_ADMIN"
+         ]
       },
       "es.upv.paella.playbackRatePlugin": {
         "enabled": true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dce-paella-extensions",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "Harvard DCE Extensions for the Paella video player",
   "main": "index.js",
   "scripts": {
@@ -31,4 +31,3 @@
   },
   "dependencies": {}
 }
-

--- a/vendor/plugins/edu.harvard.dce.paella.timedCommentsPlugin/timedCommentsOverlay.js
+++ b/vendor/plugins/edu.harvard.dce.paella.timedCommentsPlugin/timedCommentsOverlay.js
@@ -777,13 +777,15 @@ Class ("paella.plugins.TimedCommentsOverlay", paella.EventDrivenPlugin, {
     // returns a HTMLDocument, which also is a Document.
   },
   hasAdminRole: function(userRoles) {
-    var isAdmin = false;
-    this._adminRoles.forEach(function(role) {
-      if ($.inArray(role, userRoles) !== -1) {
-        isAdmin = true;
-      }
+    if (userRoles == null || !Array.isArray(this._adminRoles)) return false;
+    // Protect if Opencast sends a single value instead of an array (as it does in mp json)
+    if (!Array.isArray(userRoles)) {
+      userRoles = [userRoles];
+    }
+    return this._adminRoles.some(function(role) {
+      // Break and return true if one admin role is part of userRoles array
+      return ($.inArray(role, userRoles) !== -1);
     });
-    return isAdmin;
   },
   // TODO: move these to template files
   tc_comment: '<div class="tc_comment"><div class="tc_comment_text"></div><div class="tc_comment_data"><div class="user_icon"></div><div class="user_name"></div>, <div class="user_comment_date"></div></div></div>',


### PR DESCRIPTION
Configurable designation of access group names in the plugin config. Used for changing the display. ("admin" designation does not facilitate greater access. "admin" designation prohibits the user from creating annotations.