### PR TITLE
Update `lodash` to latest per security alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "bluebird": "^3.4.6",
     "call-next-tick": "^1.1.2",
     "jsonfile": "^2.3.1",
-    "lodash": "^3.10.1",
+    "lodash": "^4.17.11",
     "require-reload": "^0.2.2",
     "tape": "^4.2.0"
   },


### PR DESCRIPTION
I started looking at this again in the context of some usertracking plugin updates and noticed Github is reporting a couple of security vulnerabilities for the existing version of `lodash`. After updating the tests still pass, but not sure if you have additional checks to verify. I'm still in the process of re-creating a local development setup for this stuff.

Here's the relevant security issues:
* https://nvd.nist.gov/vuln/detail/CVE-2018-3721
* https://nvd.nist.gov/vuln/detail/CVE-2018-16487