### PR TITLE
OPC-400 upgrade old mobile video toggle plugin for Paella v6.2.2

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -47,6 +47,7 @@
     "audioMethods":[
        { "factory":"MultiformatAudioFactory", "enabled":true }
      ],
+     "defaultAudioTag": "en",
      "rtmpSettings": {
          "bufferTime": 5,
          "requiresSubscription": false
@@ -151,6 +152,9 @@
       },
       "edu.harvard.dce.paella.presentationOnlyPlugin": {
          "enabled": false
+      },
+      "edu.harvard.dce.paella.singleVideoTogglePlugin": {
+         "enabled": true
       },
       "edu.harvard.dce.paella.flexSkipPlugin": {
         "enabled": true,
@@ -306,9 +310,6 @@
       "edu.harvard.dce.paella.viewModeTogglePlugin": {
         "enabled": true
       },
-      "edu.harvard.dce.paella.singleVideoTogglePlugin": {
-        "enabled": false
-      },
       "es.upv.paella.socialPlugin": {
         "enabled": false
       },
@@ -317,7 +318,7 @@
       },
       "es.upv.paella.frameControlPlugin": {
         "enabled":true,
-        "showFullPreview": "auto"
+        "showFullPreview": "disable"
       },
       "edu.harvard.dce.paella.infoPlugin": {
         "enabled": true
@@ -358,9 +359,12 @@
         "enabled": true
       },
       "edu.harvard.dce.paella.iphonePluginDisablerPlugin": {
-        "** TODO: to test if still needs to be enabled": "fullScreenPlugin.getMinWindowSize & frameControlPlugin.getMinWindowSize to 10000",
+        "** Disabling for 6x": "fullScreenPlugin.getMinWindowSize & frameControlPlugin.getMinWindowSize to 10000",
         "enabled": false,
         "actiondelay":200
+      },
+      "edu.harvard.dce.safari10ExitFullScreenControlBarMagicFix": {
+        "enabled": true
       },
       "//*****  Keyboard plugins": "",
       "es.upv.paella.defaultKeysPlugin": {"enabled": true }

--- a/vendor/plugins/edu.harvard.dce.paella.captionsPlugin/captions.less
+++ b/vendor/plugins/edu.harvard.dce.paella.captionsPlugin/captions.less
@@ -1,5 +1,5 @@
-@menuBGColor: hsl(0, 0%, 15%);
-@highlightedBGColor: hsl(0, 0%, 40%);
+@menuBGColor: #262626;
+@highlightedBGColor: #666666;
 
 .buttonPlugin.dceCaptionsPluginButton{
 	background-position: -1000% -200%;
@@ -44,6 +44,7 @@
 		background: @paella_icons_image;
 		background-position: -900% -200%;
 		background-size: @paella_icons_bkg_size;
+		position: static; /* From UPV https://github.com/polimediaupv/paella/commit/7fc2a5ff13ba9415658d476294d697f925815897 */
 
 		&:hover{
 			background-color: #faa166;
@@ -59,9 +60,19 @@
   font-size:10px;
 }
 
-.captionsPluginContainer {	
-	width: 400px;
+.dceCaptionsPluginContainer {
 	overflow: hidden;
+}
+
+@media (max-width: 600px) {
+  .dceCaptionsPluginContainer {
+    width: 80vw;
+  }
+}
+@media (min-width: 601px) {
+  .dceCaptionsPluginContainer {
+    width: 400px;
+  }
 }
 
 .dceCaptionsBody {

--- a/vendor/plugins/edu.harvard.dce.paella.safari10FsExitControlBarMagicFix/safari10exitFullscreenMagicFix.js
+++ b/vendor/plugins/edu.harvard.dce.paella.safari10FsExitControlBarMagicFix/safari10exitFullscreenMagicFix.js
@@ -1,0 +1,55 @@
+// MATT-2192 Safari version 10.0.1 control bar disappears after exiting full. This is temp fix (bug was submitted via Apple developer)
+// Adapted for Paella 6.2.2  (Safari iOS fullscreen icon disappears after exiting fullscreen)
+paella.addPlugin(function () {
+  return class Safari10ExitFullScreenControlBarMagicFix extends paella.EventDrivenPlugin {
+    constructor () {
+      super ();
+    }
+    getName() {
+      return "edu.harvard.dce.safari10ExitFullScreenControlBarMagicFix";
+    }
+    getEvents() {
+      return[paella.events.exitFullscreen];
+    }
+    onEvent(eventType, params) {
+      this.magicFix();
+    }
+    checkEnabled(onSuccess) {
+      // Only for Safari
+      if (base.userAgent.browser.Safari) {
+        onSuccess(true);
+      } else {
+        onSuccess(false);
+      }
+    }
+    magicFix() {
+      if ($("#playerContainer_controls").length == 0) return;
+      var self = this;
+      var randomSmallMaxHeight = "6px";
+      var safariMagicDelayInMs = 1000;
+      var maxHeightOrig = $("#playerContainer_controls").css("max-height");
+      $("#playerContainer_controls").css({
+        "max-height": randomSmallMaxHeight
+      });
+      // Do the magic pause!
+      setTimeout(function () {
+        self.resetMaxHeight(maxHeightOrig);
+        if (base.userAgent.system.iOS) { // Mitigate missing fullScreen icon on exiting full screen in Safari iOS
+          self.retryOnExitFullScreen();
+        }
+      },
+      safariMagicDelayInMs);
+    }
+    resetMaxHeight(maxHeightOrig) {
+      $("#playerContainer_controls").css({
+        "max-height": maxHeightOrig
+      });
+    }
+    retryOnExitFullScreen() {
+      let fullScreenPlugin = paella.pluginManager.pluginList.find(p => p.getName() === "es.upv.paella.fullScreenButtonPlugin");
+      if (fullScreenPlugin && fullScreenPlugin.onExitFullscreen) {
+        fullScreenPlugin.onExitFullscreen();
+      }
+    }
+  }
+});

--- a/vendor/plugins/edu.harvard.dce.paella.singleVideoToggle/singleVideoToggle.js
+++ b/vendor/plugins/edu.harvard.dce.paella.singleVideoToggle/singleVideoToggle.js
@@ -1,149 +1,104 @@
-// #DCE SingleVideoTogglePlugin purpose: reduce bandwidth on mobile by toggling between presentation & presenter video.
-// Adapted for Paella 6.1.2 TODO: needs master-slave refactoring
+/** #DCE SingleVideoTogglePlugin
+ * Purpose: reduce bandwidth on mobile by toggling between presentation & presenter video.
+ * Uses audio from the visible track (no enabled if special HUDCE tag: multiaudio is not set)
+ *
+ * Updated for Paella 6x
+ * Adapted for Paella 6.1.2
+ * For Paella 6.2.0, the viewModeToggleProfilesPlugin module is required.
+ */
 paella.addPlugin(function () {
   return class SingleVideoTogglePlugin extends paella.ButtonPlugin {
     constructor () {
-      super();
-      this._isMaster = true;
-      this._slaveData = null;
-      this._mastereData = null;
+      super ();
+      this._iOSProfile = 'one_big';
+      this._masterVideo = null;
+      this._toggleIndex = 1; //toggle to presentation when button pressed first time
     }
     getDefaultToolTip () {
       return base.dictionary.translate("Switch videos");
     }
-    getIndex () {
-      return 451;
-    }
-    getAlignment () {
+    getAlignment() {
       return 'right';
     }
-    getSubclass () {
-      return "singleVideoToggleButton";
+    getSubclass() {
+      return "showViewModeButton";
     }
     getIconClass() {
-      return 'icon-small-screen-video-toggle';
+      return 'icon-presentation-mode';
+    }
+    getDefaultToolTip() {
+      return base.dictionary.translate("Change video layout");
+    }
+    getIndex() {
+      return 450;
+    }
+    getInstanceName() {
+      return "singleVideoTogglePlugin";
     }
     getName () {
       return "edu.harvard.dce.paella.singleVideoTogglePlugin";
     }
-    setup () {
-      // new event thrown by this plugin
-      paella.events.doneSingleVideoToggle = "dce:doneSingleVideoToggle";
-      // The sources are > 1 to get to this point
-      // TODO: this will definately not work in Paella 6.1.2
-      this._masterData = paella.dce.sources[0];
-      this._slaveData = paella.dce.sources[1];
-      // re-enable video play/pause click for ios
-      $(paella.player.videoContainer.domElement).click(function (event) {
-        paella.player.videoContainer.firstClick = false;
-      });
+    _currentPlayerProfile () {
+      return paella.player.selectedProfile;
     }
     checkEnabled (onSuccess) {
-      onSuccess(base.userAgent.system.iOS && paella.dce && paella.dce.sources && paella.dce.sources.length > 1);
+      // Only enable for iOS (not Android) TODO: test with Safari on Android?
+      onSuccess (base.userAgent.system.iOS && paella.dce && paella.dce.sources && paella.dce.sources.length > 1 && ! paella.dce.blankAudio);
     }
-    action (button) {
-      if (this._isMaster) {
-        this._isMaster = false;
-        this._toggleSources(this._slaveData);
-      } else {
-        this._isMaster = true;
-        this._toggleSources(this._masterData);
-      }
+    getCurrentMasterVideo () {
+      return paella.dce.videoPlayers.find(player => {
+        return player === paella.player.videoContainer.masterVideo();
+      });
     }
-    _toggleSources (source) {
-      var self = this;
-      var currentPlaybackRate = paella.player.videoContainer.masterVideo()._playbackRate;
-      // use current quality for toggled source in DCE requestedOrBestFitVideoQualityStrategy during reload
-      paella.dce.currentQuality = paella.player.videoContainer.masterVideo()._currentQuality;
+    action(button) {
+      let This = this;
       paella.player.videoContainer.masterVideo().getVideoData().then(function (videoData) {
+        paella.dce.videoDataSingle = videoData;
+        paella.dce.videoDataSingle.playbackRate = paella.player.videoContainer.masterVideo().video.playbackRate;
         // pause videos to temporarily stop update timers
         paella.player.videoContainer.pause().then(function () {
           paella.pluginManager.doResize = false;
-          // save current volume to player config to be used during video recreate
-          if (paella.player.config.player.audio) {
-            paella.player.config.player.audio.master = videoData.volume;
-          }
-          // Remove the existing video node
-          self._removeVideoNodes();
-          // Need to augment attributes (e.g. add type = "video/mp4")
-          paella.player.videoLoader.loadStream(source);
-          var sources =[source];
-          paella.player.videoContainer.setStreamData(sources).then(function () {
-            paella.player.videoContainer.seekToTime(videoData.currentTime);
-            // #DCE Un-pause the plugin manager's timer from looking to master video duration
-            // "paella.pluginManager.doResize" is a custom #DCE param,
-            //  see DCE opencast-paella vendor override: src/05_plugin_base.js
-            paella.pluginManager.doResize = true;
-            self._addListenerBackOntoIosVideo();
-            paella.player.videoContainer.setVolume({
-              'master': videoData.volume,
-              'slave': 0
-            }).then(function () {
-              base.log.debug("SVT: after set volume to " + videoData.volume);
-              // Reset playback rate if the playback button exists and playback rate is not the default of 1.
-              // A button onClick event is needed to correctly set the playback plugin UI
-              var playbackRateButton = $('#' + self.currentPlaybackRate.toString().replace(".", "\\.") + 'x_button');
-              if (self.currentPlaybackRate != 1 && $(playbackRateButton).length) {
-                $(playbackRateButton).click();
-              }
-              //if it was playing, play the video
-              if (! videoData.paused) {
-                paella.player.paused().then(function (stillPaused) {
-                  if (stillPaused) {
-                    paella.player.play();
-                  }
-                });
-              }
-              // completely swapping out sources requires res selection update
-              paella.events.trigger(paella.events.doneSingleVideoToggle);
-            });
-          });
+          // Remove the existing video nodes
+          This._resetVideoNodes();
+          paella.player.videoLoader._data.metadata.preview = null;
+          // toggle each source sequentially
+          let index = This._toggleIndex++ % paella.dce.sources.length;
+          paella.player.videoLoader._data.streams = [paella.dce.sources[index]];
+          // Load with the updated loader data
+          paella.player.loadVideo();
+          // reset state
+          This._resetPlayerState();
         });
       });
     }
-    _addListenerBackOntoIosVideo () {
-      // re-enable click on screen
-      paella.player.videoContainer.firstClick = false;
-      // Since this is IOS, need to re-apply the full screen listener
-      var player = document.getElementsByTagName("video")[0];
-      player.addEventListener('webkitbeginfullscreen', function (event) {
-        paella.player.play()
-      },
-      false);
-      player.addEventListener('webkitendfullscreen', function (event) {
-        paella.player.videoContainer.firstClick = false;
-        paella.player.pause();
-      },
-      false);
+    _resetPlayerState () {
+      paella.player.videoContainer.seekToTime(paella.dce.videoDataSingle.currentTime);
+      paella.player.videoContainer.setVolume(paella.dce.videoDataSingle.volume);
+      paella.player.videoContainer.setPlaybackRate(paella.dce.videoDataSingle.playbackRate);
+      // User is required to click play to restart toggled video
     }
-    
-    // in Paella5, need to manually remove nodes before reseting video source data
-    _removeVideoNodes () {
-      var video1node = paella.player.videoContainer.masterVideo();
-      var video2node = paella.player.videoContainer.slaveVideo();
-      // ensure swf object is removed
-      if (typeof swfobject !== "undefined") {
-        swfobject.removeSWF("playerContainer_videoContainer_1Movie");
-      }
-      paella.player.videoContainer.videoWrappers[0].removeNode(video1node);
-      if (video2node && paella.player.videoContainer.videoWrappers.length > 1) {
-        paella.player.videoContainer.videoWrappers[1].removeNode(video2node);
-      }
-      // empty the set of video wrappers
-      paella.player.videoContainer.videoWrappers =[];
-      // remove video container wrapper nodes
-      // TODO: needs to be refactored for 6.1.2!
-      var masterWrapper = paella.player.videoContainer.container.getNode("masterVideoWrapper");
-      paella.player.videoContainer.container.removeNode(masterWrapper);
-      var slaveWrapper = paella.player.videoContainer.container.getNode("slaveVideoWrapper");
-      if (slaveWrapper) {
-        paella.player.videoContainer.container.removeNode(slaveWrapper);
+
+    // in Paella5 & 6, must manually remove nodes before reseting video source data
+    _resetVideoNodes () {
+      for (let i = 0; i < paella.player.videoContainer.videoWrappers.length; i++) {
+        let wrapper = paella.player.videoContainer.videoWrappers[i];
+        let wrapperNodes = [].concat(wrapper.nodeList);
+        for (let j = 0; j < wrapperNodes.length; j++){
+          wrapper.removeNode(wrapperNodes[j]);
+        }
+        paella.player.videoContainer.removeNode(wrapper);
+        $("#videoPlayerWrapper_0").remove(); // because removeNode doesn't remove wrappers
       }
       // clear existing stream provider data
-      paella.player.videoContainer._streamProvider.constructor();
-      // trigger videoUnloaded event for volumecontrol save action and buffer indicator
-      paella.events.trigger(paella.events.videoUnloaded);
-      base.log.debug("PO: removed video1 and video2 nodes");
+      paella.player.videoContainer._streamProvider._mainStream = null;
+      paella.player.videoContainer._streamProvider._videoStreams = [];
+      paella.player.videoContainer._streamProvider._audioStreams = [];
+      paella.player.videoContainer._streamProvider._mainPlayer = null;
+      paella.player.videoContainer._streamProvider._audioPlayer = null;
+      paella.player.videoContainer._streamProvider._videoPlayers = [];
+      paella.player.videoContainer._streamProvider._audioPlayers = [];
+      paella.player.videoContainer._streamProvider._players = [];
+      base.log.debug("PO: removed all video nodes");
     }
   }
 });

--- a/vendor/plugins/edu.harvard.dce.paella.viewModeTogglePlugin/viewModeToggle.js
+++ b/vendor/plugins/edu.harvard.dce.paella.viewModeTogglePlugin/viewModeToggle.js
@@ -62,7 +62,7 @@ paella.addPlugin(function () {
             paella.player.setProfile(chosenProfile);
         }
         checkEnabled (onSuccess) {
-            onSuccess(! paella.player.videoContainer.isMonostream);
+            onSuccess(! paella.player.videoContainer.isMonostream && !base.userAgent.system.iOS );
         }
         // called by Mutli-Single view (presentationOnlyPlugin)
         turnOffVisibility() {

--- a/vendor/plugins/edu.harvard.dce.paella.viewModeTogglePlugin/viewModeToggleProfilesPlugin.js
+++ b/vendor/plugins/edu.harvard.dce.paella.viewModeTogglePlugin/viewModeToggleProfilesPlugin.js
@@ -8,8 +8,10 @@ paella.addProfile(() => {
       if (! available) {
         resolve(null);
       } else {
-        // do not allow multi-video to load to single video view on first load
-        if (base.cookies.get('lastProfile') === 'one_big') {
+        // do not allow multi-video to load to single video view on first load unless on an iOS
+        if (base.userAgent.system.iOS) {
+          base.cookies.set('lastProfile', 'one_big');
+        } else if (base.cookies.get('lastProfile') === 'one_big') {
           base.cookies.set('lastProfile', paella.player.config.defaultProfile || 'side_by_side');
         }
         resolve({
@@ -249,7 +251,7 @@ paella.addProfile(() => {
               "top": "0",
               "left": "0"
             }],
-            "visible": "false",
+            "visible": false,
             "layer": "2"
           }],
           background: {
@@ -264,11 +266,13 @@ paella.addProfile(() => {
           },
           switch: function () {
             // prep toggle for next setProfile
-            let v0 = this.validContent[0];
-            let v1 = this.validContent[1];
-            this.validContent[0] = v1;
-            this.validContent[1] = v0;
-            this.videos[0].content = this.validContent[0];
+            let vc0 = this.validContent[0];
+            let vc1 = this.validContent[1];
+            this.validContent[0] = vc1;
+            this.validContent[1] = vc0;
+            this.videos[0].content = vc1;
+            this.videos[1].content = vc0;
+
           }
         })
       }


### PR DESCRIPTION
Upgrade extensions to work in UPV Paella v6.2.2.
This augments and fixes issues in  the existing extension upgrade on master branch for Paella 6.1x. 