### PR TITLE
OPC-436 caption toggle fade out

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -25,11 +25,14 @@
           "*** You can add more hls.js settings here": "",
           "https://github.com/video-dev/hls.js/blob/master/docs/API.md": "",
           "maxBufferLength": 30,
-				  "maxMaxBufferLength": 600,
-				  "maxBufferSize": 60000000,
-				  "maxBufferHole": 0.5,
-				  "lowBufferWatchdogPeriod": 0.5,
-          "highBufferWatchdogPeriod": 3
+          "maxMaxBufferLength": 600,
+          "maxBufferSize": 60000000,
+          "maxBufferHole": 0.5,
+          "lowBufferWatchdogPeriod": 0.5,
+          "highBufferWatchdogPeriod": 3,
+          "capLevelToPlayerSize": false,
+          "dceHideManualQualityChoices": true,
+          "debug": true
         },
         "iOSMaxStreams": 2,
         "androidMaxStreams": 2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dce-paella-extensions",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Harvard DCE Extensions for the Paella video player",
   "main": "index.js",
   "scripts": {

--- a/vendor/plugins/edu.harvard.dce.paella.captionsPlugin/captions.less
+++ b/vendor/plugins/edu.harvard.dce.paella.captionsPlugin/captions.less
@@ -7,6 +7,8 @@
 
 /* Seleparate DCE caption plugin ids from default UPV cpation ids*/
 .dceCaptionsBar {
+		display: inline-flex;
+		width: 100%;
   input {
 		color: @popup_text_color;
 		background-color: @backgroundColor;
@@ -148,4 +150,46 @@
 	margin-right: auto;
 	padding: 8px;
 	border-radius: 12px;
+}
+
+/* =========================== */
+/* DCE Captions on-off toggle  */
+
+
+#show-captions-switch-label {
+  width: 300px;
+  margin-left: 8px;
+  margin-top: .3em;
+}
+
+.show-captions-switch-container {
+  display: inline-block;
+  width: 40px;
+}
+#show-captions-switch {
+  display: none;
+}
+.show-caption-switch-display {
+  background-color: #000;
+  color: black;
+  width: 4.8em;
+  height: 2.4em;
+  border-radius: 0.3em;
+  display: inline-block;
+  margin-left: 4px;
+  margin-top: 4px;
+  padding-left: 0.3em;
+  padding-top: 0.2em;
+}
+#show-captions-switch + .show-caption-switch-display > span {
+  padding: 0.2em 0.4em;
+  line-height: 2em;
+  font-weight: bold;
+  width: 2em;
+  border-radius: 0.3em;
+}
+#show-captions-switch:checked + .show-caption-switch-display > span.captions-on,
+#show-captions-switch:not(:checked) + .show-caption-switch-display > span.captions-off {
+  background: #fff;
+  color: #000;
 }

--- a/vendor/plugins/edu.harvard.dce.paella.infoButtonPlugin/dce_infobutton.js
+++ b/vendor/plugins/edu.harvard.dce.paella.infoButtonPlugin/dce_infobutton.js
@@ -22,6 +22,9 @@ paella.addPlugin(function () {
     getIndex () {
       return 3030;
     }
+    getAriaLabel() {
+      return base.dictionary.translate("Information");
+    }
     getMinWindowSize () {
       return 300;
     }

--- a/vendor/plugins/edu.harvard.dce.paella.singleVideoToggle/singleVideoToggle.js
+++ b/vendor/plugins/edu.harvard.dce.paella.singleVideoToggle/singleVideoToggle.js
@@ -17,6 +17,9 @@ paella.addPlugin(function () {
     getDefaultToolTip () {
       return base.dictionary.translate("Switch videos");
     }
+    getAriaLabel() {
+      return base.dictionary.translate("Switch videos");
+    }
     getAlignment() {
       return 'right';
     }
@@ -25,9 +28,6 @@ paella.addPlugin(function () {
     }
     getIconClass() {
       return 'icon-presentation-mode';
-    }
-    getDefaultToolTip() {
-      return base.dictionary.translate("Change video layout");
     }
     getIndex() {
       return 450;

--- a/vendor/plugins/edu.harvard.dce.paella.tabBarHandoutDownloadPlugin/tabBarHandoutDownload.js
+++ b/vendor/plugins/edu.harvard.dce.paella.tabBarHandoutDownloadPlugin/tabBarHandoutDownload.js
@@ -27,6 +27,9 @@ paella.addPlugin(function () {
     getDefaultToolTip() {
       return base.dictionary.translate("Class Handouts");
     }
+    getAriaLabel() {
+      return base.dictionary.translate("Handouts");
+    }
     
     buildContent(domElement) {
       this.domElement = domElement;

--- a/vendor/plugins/edu.harvard.dce.paella.timedCommentsPlugin/timedCommentsHeatmap.js
+++ b/vendor/plugins/edu.harvard.dce.paella.timedCommentsPlugin/timedCommentsHeatmap.js
@@ -35,6 +35,9 @@ paella.addPlugin(function () {
     getDefaultToolTip() {
       return base.dictionary.translate("Show comments");
     }
+    getAriaLabel() {
+      return base.dictionary.translate("Social notes");
+    }
     getName() {
       return "edu.harvard.dce.paella.timedCommentsHeatmapPlugin";
     }

--- a/vendor/plugins/edu.harvard.dce.paella.viewModeTogglePlugin/viewModeToggle.js
+++ b/vendor/plugins/edu.harvard.dce.paella.viewModeTogglePlugin/viewModeToggle.js
@@ -27,6 +27,9 @@ paella.addPlugin(function () {
         getIndex () {
             return 450;
         }
+        getAriaLabel() {
+            return base.dictionary.translate("Switch video layouts");
+        }
         getAlignment () {
             return 'right';
         }


### PR DESCRIPTION
This pull changes the DCE variation of the captions plugin for hiding when the the transcription popup looses focus. In order to accomplish that, the on-off toggle UI had to be reworked. That caused the bulk of the changes in this pull.

Other changes: 
- corrected config alignment and added debug param for hls.js by default (until HLS.js params are finished being established)
- added method to 3 DCE control bar plugins to make them tab navigation accessible.

i.e
OPC-436 Player transcription popup - simplify on-off toggle and hide popup when it looses focus.
OPC-429 Player: when transcription popup is open, video ends and is restarted, they don't scroll back to top
OPC-427 Player (existing issue) Transcription seek doesn't factor trimmed start when seeking to timepoint
OPC-447 Player: Tab navigation missing on DCE plugins in updated player
OPC-452  config param to disable manual override of HLS (dceHideManualQualityChoices)
