### PR TITLE
T/opc 497 hls live player updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dce-paella-extensions",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Harvard DCE Extensions for the Paella video player",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The HLS Live v1 with single video and 2 m3u8 masters (one for each resolution), overloads the Single Video Toggle  plugin we use for toggling 2 videos in IOS mobile. It is the same concept and the same goals.