### PR TITLE
OPC-552 (prep for OPC-550 HLS) Updates for Paella 6.4.3 upgrade

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -15,6 +15,7 @@
     },
     "profileFrameStrategy": "paella.ProfileFrameStrategy",
     "videoQualityStrategy": "paella.RequestedOrBestFitVideoQualityStrategy",
+    "videoQualityStrategyParams":{ "maxAutoQualityRes":4999 },
     "#DCE reloading video on full screen is problematic with rtmp live streams":"",
     "reloadOnFullscreen": false,
     "methods": [
@@ -35,7 +36,8 @@
           "debug": true
         },
         "iOSMaxStreams": 2,
-        "androidMaxStreams": 2
+        "androidMaxStreams": 2,
+        "initialQualityLevel": 4
        },
        { "factory":"ChromaVideoFactory", "enabled":true },
        { "factory":"WebmVideoFactory", "enabled":true },
@@ -109,8 +111,11 @@
           }
         ],
         "audioTag": {
+        },
+        "videoCanvas": {
+          "*/delivery+360": "video360",
+          "*/delivery+360Theta": "video360Theta"
         }
-
       },
       "//**** Video profile plugins": "",
       "es.upv.paella.singleStreamProfilePlugin": {
@@ -151,13 +156,15 @@
       "edu.harvard.edu.paella.singleMultipleQualitiesPlugin" : {
          "enabled": false,
          "showWidthRes":true,
-         "presenterHasAudioTag":"multiaudio"
+         "presenterHasAudioTag":"multiaudio",
+         "ariaLabel": "Change video quality"
       },
       "edu.harvard.dce.paella.presentationOnlyPlugin": {
          "enabled": false
       },
       "edu.harvard.dce.paella.singleVideoTogglePlugin": {
-         "enabled": true
+         "enabled": true,
+         "ariaLabel": "Switch Videos"
       },
       "edu.harvard.dce.paella.flexSkipPlugin": {
         "enabled": true,
@@ -193,7 +200,8 @@
 
       "es.upv.paella.multipleQualitiesPlugin": {
         "enabled": true,
-        "showWidthRes": true
+        "showWidthRes": true,
+        "minVisibleQuality": 60
       },
       "es.upv.paella.ImageControlPlugin": {
         "enabled": false
@@ -237,7 +245,8 @@
       "es.upv.paella.volumeRangePlugin": {
         "enabled": true,
         "showMasterVolume": true,
-        "showSlaveVolume": false
+        "showSlaveVolume": false,
+        "ariaLabel": "Volume"
       },
       "edu.harvard.dce.paella.heartbeatSender": {
         "enabled": true,
@@ -292,13 +301,22 @@
         "//*** DCE TODO: vet this plugin in a separate release":"",
         "enabled": false
       },
+      "es.upv.paella.timeMarksPlaybackCanvasPlugin": {
+        "enabled": true,
+        "color": "gray"
+      },
+      "es.upv.paella.BufferedPlaybackCanvasPlugin": {
+        "enabled": true,
+        "color": "rgba(0,0,0,0.4)"
+      },
       "es.upv.paella.fullScreenButtonPlugin": {
         "enabled": true,
         "reloadOnFullscreen": {
           "//": "#DCE reloading video on full screen is problematic with rtmp live streams",
           "enabled": false,
           "keepUserSelection": true
-        }
+        },
+        "ariaLabel": "Switch full screen mode"
       },
       "es.upv.paella.extendedProfilesPlugin": {
         "enabled": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dce-paella-extensions",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Harvard DCE Extensions for the Paella video player",
   "main": "index.js",
   "scripts": {

--- a/vendor/plugins/edu.harvard.dce.paella.viewModeTogglePlugin/viewModeToggle.js
+++ b/vendor/plugins/edu.harvard.dce.paella.viewModeTogglePlugin/viewModeToggle.js
@@ -57,7 +57,8 @@ paella.addPlugin(function () {
                 chosenProfile = this._currentPlayerProfile();
                 this.toggleProfileVideos(chosenProfile);
             }
-            base.log.debug("Now triggering event setProfile on '" + chosenProfile + "' toggling video '" + toToggle + "'");
+            // #DCE OPC-455 log
+            base.log.debug(`OPC-455 viewModeTogglePlugin setProfile '${chosenProfile}' on '${toToggle}'`);
             var overlayContainer = paella.player.videoContainer.overlayContainer;
             if (overlayContainer) {
                 overlayContainer.clear();
@@ -77,6 +78,7 @@ paella.addPlugin(function () {
         turnOnVisibility() {
             this.config.visibleOn = undefined;
             this.checkVisibility();
+            base.log.debug(`OPC-455 viewModeTogglePlugin turnOnVisibility, time '${new Date()}'`);
         }
         toggleProfileVideos(profileId) {
             let profile = paella.profiles.getProfile(profileId);

--- a/vendor/skins/cs50.less
+++ b/vendor/skins/cs50.less
@@ -88,8 +88,20 @@ img#playerContainer_videoContainer_bkg{
   display: none;
 }
 
+/* Important to override position for cs50 style scrub bar */
 div.timeControl {
   color: #555;
+}
+
+/* Important to override position for cs50 style scrub bar */
+div.timeControl, .playbackBarFull {
+  top: unset !important;
+  position: unset !important;
+}
+
+/* Important to override position for cs50 style scrub bar */
+.playerContainer_controls_playback_playbackBar_canvas {
+  display: none;
 }
 
 div#playerContainer_controls_playback_playbackBar {


### PR DESCRIPTION
OPC-552 (prep for OPC-550 HLS) Upgrade extensions and config for Paella 6.4.3

The 3 changes:
1. Extra CS50 style override for UPV6.4.3 playbackbar
2. Config additions and updates
3. DCE custom Singlevideo toggle plugin (iOS presenter/presentation toggle) promise chain required reworking for Paella 6.4.3

