### PR TITLE
OPC-566 HLS config: start at higher res, wait to start load  until HLS config

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -33,7 +33,11 @@
           "highBufferWatchdogPeriod": 3,
           "capLevelToPlayerSize": false,
           "dceHideManualQualityChoices": true,
-          "debug": true
+          "debug": true,
+          "testBandwidth" : false,
+          "initialQualityLevel": 4,
+          "startLevel" : 4,
+          "autoStartLoad" : false
         },
         "iOSMaxStreams": 2,
         "androidMaxStreams": 2,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dce-paella-extensions",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Harvard DCE Extensions for the Paella video player",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Player config updated to support better HLS load behavior.