### PR TITLE
Tabindex controlbar controls 

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -166,11 +166,13 @@
         "enabled": true,
         "direction": "Rewind",
         "seconds": 10,
+        "ariaLabel": "Go back 10 seconds",
         "minWindowSize": 510
       },
       "edu.harvard.dce.paella.flexSkipForwardPlugin": {
         "enabled": true,
         "direction": "Forward",
+        "ariaLabel": "Go forward 30 seconds",
         "seconds": 30,
         "minWindowSize": 510
       },
@@ -265,6 +267,7 @@
       },
       "es.upv.paella.playbackRatePlugin": {
         "enabled": true,
+        "ariaLabel": "Change playback rate",
         "availableRates": [
           0.75,
           1,
@@ -345,6 +348,7 @@
       },
       "es.upv.paella.frameControlPlugin": {
         "enabled":true,
+        "ariaLabel": "Navigate by slide images",
         "showFullPreview": "disable"
       },
       "edu.harvard.dce.paella.infoPlugin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dce-paella-extensions",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "Harvard DCE Extensions for the Paella video player",
   "main": "index.js",
   "scripts": {

--- a/vendor/skins/cs50.less
+++ b/vendor/skins/cs50.less
@@ -64,6 +64,11 @@ body {
   }
 }
 
+/* OPC-748 increase tab focus visual indicator */
+.buttonPlugin:focus {
+  box-shadow: inset 0px 0px 8px 0px #6495ed !important;
+}
+
 div.buttonPluginPopUp{
   background-color: #333;
   border: 1px solid #555;


### PR DESCRIPTION
Update version 2.10.0
OPC-747 - put all controls that are 'enter' key actionable into tab index
OPC-748 - visually enhance the control that is in focus

Companion pull in bitbucket for DCE OC