### PR TITLE
OPC-759 patch scrollpoint when adding a comment or reply

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dce-paella-extensions",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "description": "Harvard DCE Extensions for the Paella video player",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The scroll point was not bouncing back the existing manual scroll point after submitting a reply or comment. 

This pull 
- patches a reference to _me was me, and a patch on the OC server side adds the DCE custom timestamp
- patches the reloadComments  promise chain that was in error since the trim-notes patch
- ensures the reference to the current scroll top position is preserved on refresh

Associated QA-1251
Has a companion Bitbucket pull 